### PR TITLE
[MINT-3212]/category reorder to parent

### DIFF
--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -3065,45 +3065,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "mutation ReorderMTOCategory {\nreorderMTOCategory(id: \"{{mtoCategoryID}}\",\nnewOrder: 0\n) {\n    position\n    id\n    name\n    isUncategorized\n    }\n}",
-										"variables": ""
-									}
-								},
-								"url": {
-									"raw": "{{url}}",
-									"host": [
-										"{{url}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "RenameMTOSubcategory",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"exec": [
-											"let responseData = pm.response.json().data.createMTOCategory",
-											"",
-											"mtoCategoryID = responseData.id",
-											"",
-											"",
-											"pm.collectionVariables.set(\"mtoCategoryID\", mtoCategoryID);"
-										],
-										"type": "text/javascript",
-										"packages": {}
-									}
-								}
-							],
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "graphql",
-									"graphql": {
-										"query": "mutation RenameMTOSubcategory {\nrenameMTOCategory(id: \"{{mtoSubcategoryID}}\",\nname: \"Awesome renamed Sub Category\"\n# ,parentID: \"{{mtoCategoryID}}\"\n) {\n    id\n    name\n    isUncategorized\n    }\n}",
+										"query": "mutation ReorderMTOCategory {\nreorderMTOCategory(id: \"{{mtoCategoryID}}\"\n,newOrder: 0\n# ,parentID: \"{{mtoCategoryID}}\"\n) {\n    position\n    id\n    name\n    isUncategorized\n    }\n}",
 										"variables": ""
 									}
 								},
@@ -3142,6 +3104,77 @@
 									"mode": "graphql",
 									"graphql": {
 										"query": "mutation NewMTOCategory {\ncreateMTOCategory(modelPlanID: \"{{modelPlanID}}\",\nname: \"Awesome Sub Category 0\"\n,parentID: \"{{mtoCategoryID}}\"\n) {\n    id\n    name\n    isUncategorized\n    position\n    }\n}",
+										"variables": ""
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Reorder MTO Subcategory",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation ReorderMTOCategory {\nreorderMTOCategory(id: \"{{mtoSubcategoryID}}\"\n# ,newOrder: 0\n,parentID: \"{{mtoCategoryID}}\"\n) {\n    position\n    id\n    name\n    isUncategorized\n    }\n}",
+										"variables": ""
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "RenameMTOSubcategory",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let responseData = pm.response.json().data.createMTOCategory",
+											"",
+											"mtoCategoryID = responseData.id",
+											"",
+											"",
+											"pm.collectionVariables.set(\"mtoCategoryID\", mtoCategoryID);"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation RenameMTOSubcategory {\nrenameMTOCategory(id: \"{{mtoSubcategoryID}}\",\nname: \"Awesome renamed Sub Category\"\n# ,parentID: \"{{mtoCategoryID}}\"\n) {\n    id\n    name\n    isUncategorized\n    }\n}",
 										"variables": ""
 									}
 								},

--- a/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
+++ b/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
@@ -29,17 +29,50 @@ BEGIN
     
     -- Handle Update: Reorder positions when a row's position is changed 
     ELSIF TG_OP = 'UPDATE' THEN
-        -- Determine if record moved up or down
-        IF NEW.position > OLD.position THEN
-            position_adjustment := -1;
-        ELSE
-            position_adjustment := 1;
-        END IF;
+    IF OLD.model_plan_id IS DISTINCT FROM NEW.model_plan_id THEN
+        RAISE EXCEPTION 'updating model_plan_id is not allowed. Caught in trigger function update_position_based_on_parent_and_model_plan';
+    END IF;
 
  /* Prevent updates to model_plan_id and parent_id as these are fixed for each category */
-        IF OLD.parent_id IS DISTINCT FROM NEW.parent_id AND OLD.model_plan_id IS DISTINCT FROM NEW.model_plan_id THEN
-        RAISE EXCEPTION 'updating model_plan_id or parent_id is not allows. Caught in trigger function update_position_based_on_parent_and_model_plan';
-        ELSIF OLD.parent_id IS NOT DISTINCT FROM NEW.parent_id AND OLD.model_plan_id IS NOT DISTINCT FROM NEW.model_plan_id THEN
+        IF OLD.parent_id IS DISTINCT FROM NEW.parent_id THEN
+        /*
+        Handle the old parent changes like a delete, move all lower categories up one for old parent
+        */
+        UPDATE mto_category
+        SET position = position - 1,
+            modified_by = NEW.modified_by,
+            modified_dts = NEW.modified_dts
+        WHERE ((parent_id IS NULL AND OLD.parent_id IS NULL) OR (parent_id = OLD.parent_id))
+          AND ((model_plan_id IS NULL AND OLD.model_plan_id IS NULL) OR (model_plan_id = OLD.model_plan_id))
+          AND position > OLD.position
+          AND id != OLD.id;  -- Exclude the deleted row
+
+          /* 
+          Handle the new row position like an insert
+          */
+
+        -- Move categories with the same parent_id and model_plan_id that have a position >= NEW.position
+        position_adjustment := 1;  -- For insert, we increase positions of conflicting rows
+        UPDATE mto_category
+        SET position = position + position_adjustment,
+            modified_by = NEW.modified_by,
+            modified_dts = NEW.modified_dts
+        WHERE ((parent_id IS NULL AND NEW.parent_id IS NULL) OR (parent_id = NEW.parent_id))
+          AND ((model_plan_id IS NULL AND NEW.model_plan_id IS NULL) OR (model_plan_id = NEW.model_plan_id))
+          AND position >= NEW.position
+          AND id != NEW.id;  -- Exclude the newly inserted row
+
+        -- Make this a distinct check to see if position has changed at all. If not, don't trigger this.
+        ELSIF OLD.parent_id IS NOT DISTINCT FROM NEW.parent_id  THEN
+            -- If the position is unchanged, no further action is required    
+            IF NEW.position = OLD.position THEN
+                RETURN NEW;
+            -- Determine if record moved up or down
+            ELSIF NEW.position > OLD.position THEN
+                position_adjustment := -1;
+            ELSE
+                position_adjustment := 1;
+            END IF;
             IF position_adjustment = -1 THEN
             /* Row moved down: Shift rows in the range [OLD.position + 1, NEW.position] up by 1 */
                 UPDATE mto_category

--- a/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
+++ b/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
@@ -34,10 +34,10 @@ BEGIN
         RAISE EXCEPTION 'updating model_plan_id is not allowed. Caught in trigger function update_position_based_on_parent_and_model_plan';
     END IF;
 
-        IF OLD.parent_id IS DISTINCT FROM NEW.parent_id THEN
         /*
         Handle the old parent changes like a delete, move all lower categories up one for old parent
         */
+        IF OLD.parent_id IS DISTINCT FROM NEW.parent_id THEN
         UPDATE mto_category
         SET position = position - 1,
             modified_by = NEW.modified_by,

--- a/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
+++ b/migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
@@ -29,11 +29,11 @@ BEGIN
     
     -- Handle Update: Reorder positions when a row's position is changed 
     ELSIF TG_OP = 'UPDATE' THEN
+    /* Prevent updates to model_plan_id as categories cannot move from one model plan to another */
     IF OLD.model_plan_id IS DISTINCT FROM NEW.model_plan_id THEN
         RAISE EXCEPTION 'updating model_plan_id is not allowed. Caught in trigger function update_position_based_on_parent_and_model_plan';
     END IF;
 
- /* Prevent updates to model_plan_id and parent_id as these are fixed for each category */
         IF OLD.parent_id IS DISTINCT FROM NEW.parent_id THEN
         /*
         Handle the old parent changes like a delete, move all lower categories up one for old parent

--- a/pkg/graph/resolvers/mto_category.go
+++ b/pkg/graph/resolvers/mto_category.go
@@ -60,8 +60,12 @@ func MTOCategoryRename(ctx context.Context, logger *zap.Logger, principal authen
 // MTOCategoryReorder updates the position of an MTOCategory or SubCategory
 func MTOCategoryReorder(ctx context.Context, logger *zap.Logger, principal authentication.Principal, store *storage.Store,
 	id uuid.UUID,
-	order int,
+	order *int,
+	parentID *uuid.UUID,
 ) (*models.MTOCategory, error) {
+	if order == nil && parentID == nil {
+		return nil, fmt.Errorf(" either order or parentID must be provided for MTOCategoryReorder")
+	}
 	principalAccount := principal.Account()
 	if principalAccount == nil {
 		return nil, fmt.Errorf("principal doesn't have an account, username %s", principal.String())
@@ -72,7 +76,15 @@ func MTOCategoryReorder(ctx context.Context, logger *zap.Logger, principal authe
 	}
 	// update the position to the new value
 	// the re-ordering of other rows is handled in the trigger added in migrations/V188__Add_MTO_Category_Reorder_Trigger.sql
-	existing.Position = order
+	if order != nil {
+		existing.Position = *order
+	}
+	if parentID != nil {
+		if existing.ParentID == nil {
+			return nil, fmt.Errorf("you cannot provide a parent id for a parent category")
+		}
+		existing.ParentID = parentID
+	}
 
 	// Just check access, don't apply changes here
 	err = BaseStructPreUpdate(logger, existing, map[string]interface{}{}, principal, store, false, true)

--- a/pkg/graph/resolvers/mto_category.resolvers.go
+++ b/pkg/graph/resolvers/mto_category.resolvers.go
@@ -52,10 +52,10 @@ func (r *mutationResolver) RenameMTOCategory(ctx context.Context, id uuid.UUID, 
 }
 
 // ReorderMTOCategory is the resolver for the reorderMTOCategory field.
-func (r *mutationResolver) ReorderMTOCategory(ctx context.Context, id uuid.UUID, newOrder int) (*models.MTOCategory, error) {
+func (r *mutationResolver) ReorderMTOCategory(ctx context.Context, id uuid.UUID, newOrder *int, parentID *uuid.UUID) (*models.MTOCategory, error) {
 	principal := appcontext.Principal(ctx)
 	logger := appcontext.ZLogger(ctx)
-	return MTOCategoryReorder(ctx, logger, principal, r.store, id, newOrder)
+	return MTOCategoryReorder(ctx, logger, principal, r.store, id, newOrder, parentID)
 }
 
 // MTOCategory returns generated.MTOCategoryResolver implementation.

--- a/pkg/graph/resolvers/mto_category_test.go
+++ b/pkg/graph/resolvers/mto_category_test.go
@@ -584,3 +584,28 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToNewParentOrderNotSpecifie
 	suite.EqualValues(plan2CatSub.ID, retSubCategoriesPlan2[0].ID, "Category 2 Sub should remain in position 0")
 	/*end */
 }
+
+// TestMTOCantMakeParentCategorySubCategory validates that a parent can't be made a child category
+func (suite *ResolverSuite) TestMTOCantMakeParentCategorySubCategory() {
+	plan := suite.createModelPlan("Testing Plan for Reordering")
+
+	// Create multiple categories for model plan
+	cat0Name := "Category 0"
+	cat1Name := "Category 1"
+	cat2Name := "Category 2"
+
+	names := []string{cat0Name, cat1Name, cat2Name}
+	categories := suite.createMultipleMTOcategories(names, plan.ID, nil)
+	suite.Len(categories, 3)
+
+	cat0, cat1, cat2 := categories[0], categories[1], categories[2]
+
+	//Try to move cat 1 to be a child of cat 0
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat1.ID, nil, &cat0.ID)
+	suite.Error(err, "we expect that you can't make a parent category a child category. There should be an error for this operation.")
+
+	// Try to reorder without specifying a new position or a new parent. Expect an error
+	_, err2 := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2.ID, nil, nil)
+	suite.Error(err2, "we expect that you can't reorder without specifying both order and parent . There should be an error for this operation.")
+
+}

--- a/pkg/graph/resolvers/mto_category_test.go
+++ b/pkg/graph/resolvers/mto_category_test.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"github.com/google/uuid"
 
+	"github.com/cms-enterprise/mint-app/pkg/helpers"
 	"github.com/cms-enterprise/mint-app/pkg/models"
 )
 
@@ -204,7 +205,7 @@ func (suite *ResolverSuite) TestMTOCategoryReorderToPositionZero() {
 	suite.Equal(0, plan2CatSub.Position)
 
 	// Move cat2 to position 0 and verify reordering
-	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2.ID, 0)
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2.ID, helpers.PointerTo[int](0), nil)
 	suite.NoError(err)
 
 	// Verify positions after reordering
@@ -265,7 +266,7 @@ func (suite *ResolverSuite) TestMTOCategoryReorderToPositionTwo() {
 	suite.Equal(0, plan2CatSub.Position)
 
 	// Move cat0 to position 2 and verify reordering
-	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat0.ID, 2)
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat0.ID, helpers.PointerTo[int](2), nil)
 	suite.NoError(err)
 
 	// Verify positions after reordering
@@ -328,7 +329,7 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionTwo() {
 
 	// reorder the subcategory
 	// Move cat2Sub0 to position 2 and verify reordering
-	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub0.ID, 2)
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub0.ID, helpers.PointerTo[int](2), nil)
 	suite.NoError(err)
 
 	retSubcategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat2.ID)
@@ -392,7 +393,7 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionZero() {
 
 	// reorder the subcategory
 	// Move cat2Sub0 to position 2 and verify reordering
-	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub2.ID, 0)
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub2.ID, helpers.PointerTo[int](0), nil)
 	suite.NoError(err)
 
 	retSubcategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat2.ID)

--- a/pkg/graph/resolvers/mto_category_test.go
+++ b/pkg/graph/resolvers/mto_category_test.go
@@ -425,3 +425,82 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionZero() {
 	suite.EqualValues(plan2CatSub.ID, retSubCategoriesPlan2[0].ID, "Category 2 Sub should remain in position 0")
 	/*end */
 }
+
+// TestMTOSubCategoryReorderToPositionTwo validates that the sub categories move as expected
+func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionTwoOfNewParent() {
+	plan := suite.createModelPlan("Testing Plan for Reordering")
+
+	// Create multiple categories for model plan
+	cat0Name := "Category 0"
+	cat0Sub0Name := "Category 0 Sub 0"
+	cat0Sub1Name := "Category 0 Sub 1"
+	cat1Name := "Category 1"
+	cat2Name := "Category 2"
+	cat2Sub0Name := "Category 2 Sub 0"
+	cat2Sub1Name := "Category 2 Sub 1"
+	cat2Sub2Name := "Category 2 Sub 2"
+	names := []string{cat0Name, cat1Name, cat2Name}
+	categories := suite.createMultipleMTOcategories(names, plan.ID, nil)
+	suite.Len(categories, 3)
+
+	cat0, cat1, cat2 := categories[0], categories[1], categories[2]
+
+	// Make child for category 2
+	subCategoryNames := []string{cat2Sub0Name, cat2Sub1Name, cat2Sub2Name}
+	cat2SubCategories := suite.createMultipleMTOcategories(subCategoryNames, plan.ID, &cat2.ID)
+	cat2Sub0, cat2Sub1, cat2Sub2 := cat2SubCategories[0], cat2SubCategories[1], cat2SubCategories[2]
+	cat0SubCategories := suite.createMultipleMTOcategories([]string{cat0Sub0Name, cat0Sub1Name}, plan.ID, &cat0.ID)
+	cat0Sub0, cat0Sub1 := cat0SubCategories[0], cat0SubCategories[1]
+
+	// Create a category for another model plan
+	plan2 := suite.createModelPlan("Testing Plan for Multiple Categories")
+	plan2Cat := suite.createMTOCategory("placeholder", plan2.ID, nil)
+	plan2CatSub := suite.createMTOCategory("placeholder sub", plan2.ID, &plan2Cat.ID)
+	suite.Equal(0, plan2Cat.Position)
+	suite.Equal(0, plan2CatSub.Position)
+
+	// reorder the subcategory
+	// Move cat2Sub0 to position 0 of cat0 and verify reordering
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub0.ID, helpers.PointerTo[int](0), &cat0.ID)
+	suite.NoError(err)
+
+	// validate the position of subcategories of old parent
+	retSubcategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat2.ID)
+	suite.Len(retSubcategories, 3)
+	suite.NoError(err)
+	suite.EqualValues(cat2Sub1.ID, retSubcategories[0].ID, "Subcategory 1 should now be in position 0")
+	suite.EqualValues(cat2Sub2.ID, retSubcategories[1].ID, "Subcategory 2 should move to position 1")
+	suite.EqualValues(uuid.Nil, retSubcategories[2].ID, "Uncategorized should be in position 2")
+
+	// validate the position of subcategories of new parent
+	retNewCategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat0.ID)
+	suite.Len(retNewCategories, 4)
+	suite.NoError(err)
+	suite.EqualValues(cat2Sub0.ID, retNewCategories[0].ID, "Subcategory 0 from cat 2 should move to position 0 in new parent")
+	suite.EqualValues(cat0Sub0.ID, retNewCategories[1].ID, "Subcategory 0 from cat 0 should move to position 1 in new parent")
+	suite.EqualValues(cat0Sub1.ID, retNewCategories[2].ID, "Subcategory 1 from cat 0 should move to position 2 in new parent")
+	suite.EqualValues(uuid.Nil, retNewCategories[3].ID, "Uncategorized should be in position 3 in new parent")
+
+	// Verify positions after reordering
+	//verify parent categories are unaffected
+	retCategories, err := MTOCategoryGetByModelPlanIDLOADER(suite.testConfigs.Context, plan.ID)
+	suite.NoError(err)
+	suite.Len(retCategories, 4)
+
+	suite.EqualValues(cat0.ID, retCategories[0].ID, "Category 0 should now be in position 0")
+	suite.EqualValues(cat1.ID, retCategories[1].ID, "Category 1 should move to position 1")
+	suite.EqualValues(cat2.ID, retCategories[2].ID, "Category 2 should move to position 2")
+
+	/***** verify that a category for another model plan isn't updated
+	*****/
+	// Verify positions after reordering for other Model Plan
+	retCategoriesPLan2, err := MTOCategoryGetByModelPlanIDLOADER(suite.testConfigs.Context, plan2.ID)
+	suite.NoError(err)
+	suite.Len(retCategoriesPLan2, 2)
+	//Verify that a child category isn't updated if parent is reordered
+	retSubCategoriesPlan2, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan2.ID, plan2Cat.ID)
+	suite.NoError(err)
+	suite.Len(retSubCategoriesPlan2, 2, "There should be two sub categories (including uncategorized)")
+	suite.EqualValues(plan2CatSub.ID, retSubCategoriesPlan2[0].ID, "Category 2 Sub should remain in position 0")
+	/*end */
+}

--- a/pkg/graph/resolvers/mto_category_test.go
+++ b/pkg/graph/resolvers/mto_category_test.go
@@ -426,8 +426,8 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionZero() {
 	/*end */
 }
 
-// TestMTOSubCategoryReorderToPositionTwo validates that the sub categories move as expected
-func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionTwoOfNewParent() {
+// TestMTOSubCategoryReorderToPositionZero validates that the sub categories move as expected
+func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionZeroOfNewParent() {
 	plan := suite.createModelPlan("Testing Plan for Reordering")
 
 	// Create multiple categories for model plan
@@ -479,6 +479,86 @@ func (suite *ResolverSuite) TestMTOSubCategoryReorderToPositionTwoOfNewParent() 
 	suite.EqualValues(cat2Sub0.ID, retNewCategories[0].ID, "Subcategory 0 from cat 2 should move to position 0 in new parent")
 	suite.EqualValues(cat0Sub0.ID, retNewCategories[1].ID, "Subcategory 0 from cat 0 should move to position 1 in new parent")
 	suite.EqualValues(cat0Sub1.ID, retNewCategories[2].ID, "Subcategory 1 from cat 0 should move to position 2 in new parent")
+	suite.EqualValues(uuid.Nil, retNewCategories[3].ID, "Uncategorized should be in position 3 in new parent")
+
+	// Verify positions after reordering
+	//verify parent categories are unaffected
+	retCategories, err := MTOCategoryGetByModelPlanIDLOADER(suite.testConfigs.Context, plan.ID)
+	suite.NoError(err)
+	suite.Len(retCategories, 4)
+
+	suite.EqualValues(cat0.ID, retCategories[0].ID, "Category 0 should now be in position 0")
+	suite.EqualValues(cat1.ID, retCategories[1].ID, "Category 1 should move to position 1")
+	suite.EqualValues(cat2.ID, retCategories[2].ID, "Category 2 should move to position 2")
+
+	/***** verify that a category for another model plan isn't updated
+	*****/
+	// Verify positions after reordering for other Model Plan
+	retCategoriesPLan2, err := MTOCategoryGetByModelPlanIDLOADER(suite.testConfigs.Context, plan2.ID)
+	suite.NoError(err)
+	suite.Len(retCategoriesPLan2, 2)
+	//Verify that a child category isn't updated if parent is reordered
+	retSubCategoriesPlan2, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan2.ID, plan2Cat.ID)
+	suite.NoError(err)
+	suite.Len(retSubCategoriesPlan2, 2, "There should be two sub categories (including uncategorized)")
+	suite.EqualValues(plan2CatSub.ID, retSubCategoriesPlan2[0].ID, "Category 2 Sub should remain in position 0")
+	/*end */
+}
+
+// TestMTOSubCategoryReorderToPositionTwo validates that the sub categories move as expected
+func (suite *ResolverSuite) TestMTOSubCategoryReorderToNewParentOrderNotSpecified() {
+	plan := suite.createModelPlan("Testing Plan for Reordering")
+
+	// Create multiple categories for model plan
+	cat0Name := "Category 0"
+	cat0Sub0Name := "Category 0 Sub 0"
+	cat0Sub1Name := "Category 0 Sub 1"
+	cat1Name := "Category 1"
+	cat2Name := "Category 2"
+	cat2Sub0Name := "Category 2 Sub 0"
+	cat2Sub1Name := "Category 2 Sub 1"
+	cat2Sub2Name := "Category 2 Sub 2"
+	names := []string{cat0Name, cat1Name, cat2Name}
+	categories := suite.createMultipleMTOcategories(names, plan.ID, nil)
+	suite.Len(categories, 3)
+
+	cat0, cat1, cat2 := categories[0], categories[1], categories[2]
+
+	// Make child for category 2
+	subCategoryNames := []string{cat2Sub0Name, cat2Sub1Name, cat2Sub2Name}
+	cat2SubCategories := suite.createMultipleMTOcategories(subCategoryNames, plan.ID, &cat2.ID)
+	cat2Sub0, cat2Sub1, cat2Sub2 := cat2SubCategories[0], cat2SubCategories[1], cat2SubCategories[2]
+	cat0SubCategories := suite.createMultipleMTOcategories([]string{cat0Sub0Name, cat0Sub1Name}, plan.ID, &cat0.ID)
+	cat0Sub0, cat0Sub1 := cat0SubCategories[0], cat0SubCategories[1]
+
+	// Create a category for another model plan
+	plan2 := suite.createModelPlan("Testing Plan for Multiple Categories")
+	plan2Cat := suite.createMTOCategory("placeholder", plan2.ID, nil)
+	plan2CatSub := suite.createMTOCategory("placeholder sub", plan2.ID, &plan2Cat.ID)
+	suite.Equal(0, plan2Cat.Position)
+	suite.Equal(0, plan2CatSub.Position)
+
+	// reorder the subcategory
+	// Move cat2Sub0 to undefined position of cat0 and verify reordering to the last position
+	_, err := MTOCategoryReorder(suite.testConfigs.Context, suite.testConfigs.Logger, suite.testConfigs.Principal, suite.testConfigs.Store, cat2Sub0.ID, nil, &cat0.ID)
+	suite.NoError(err)
+
+	// validate the position of subcategories of old parent
+	retSubcategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat2.ID)
+	suite.Len(retSubcategories, 3)
+	suite.NoError(err)
+	suite.EqualValues(cat2Sub1.ID, retSubcategories[0].ID, "Subcategory 1 should now be in position 0")
+	suite.EqualValues(cat2Sub2.ID, retSubcategories[1].ID, "Subcategory 2 should move to position 1")
+	suite.EqualValues(uuid.Nil, retSubcategories[2].ID, "Uncategorized should be in position 2")
+
+	// validate the position of subcategories of new parent
+	retNewCategories, err := MTOSubcategoryGetByParentIDLoader(suite.testConfigs.Context, plan.ID, cat0.ID)
+	suite.Len(retNewCategories, 4)
+	suite.NoError(err)
+
+	suite.EqualValues(cat0Sub0.ID, retNewCategories[0].ID, "Subcategory 0 from cat 0 should move to position 0 in new parent")
+	suite.EqualValues(cat0Sub1.ID, retNewCategories[1].ID, "Subcategory 1 from cat 0 should move to position 1 in new parent")
+	suite.EqualValues(cat2Sub0.ID, retNewCategories[2].ID, "Subcategory 0 from cat 2 should move to position 2 in new parent")
 	suite.EqualValues(uuid.Nil, retNewCategories[3].ID, "Uncategorized should be in position 3 in new parent")
 
 	// Verify positions after reordering

--- a/pkg/graph/schema/types/mto_category.graphql
+++ b/pkg/graph/schema/types/mto_category.graphql
@@ -37,6 +37,12 @@ extend type Mutation {
   renameMTOCategory(id: UUID!, name: String!): MTOCategory!
   @hasRole(role: MINT_USER)
 
-  reorderMTOCategory(id: UUID!, newOrder: Int!): MTOCategory!
+  """
+  Allows you to change the position and parent of an MTO category. Other categories will automatically
+  have their positions changed to adjust to the new position of the new category.
+  If only the parent is changed, the category will be placed as the last category in order for the group of subcategories
+  Note, a subcategory can't become a subcategory and vice versa
+  """
+  reorderMTOCategory(id: UUID!, newOrder: Int, parentID: UUID): MTOCategory!
   @hasRole(role: MINT_USER)
 }

--- a/pkg/sqlqueries/SQL/mto/category/update.sql
+++ b/pkg/sqlqueries/SQL/mto/category/update.sql
@@ -2,6 +2,7 @@ UPDATE mto_category
 SET 
     name= :name,
     position= :position,
+    parent_id= :parent_id,
     modified_by= :modified_by,
     modified_dts= CURRENT_TIMESTAMP
 WHERE  mto_category.id = :id

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1122,6 +1122,12 @@ export type Mutation = {
    * You cannot have a duplicate name per model plan and parent. If the change makes a conflict, this will error.
    */
   renameMTOCategory: MtoCategory;
+  /**
+   * Allows you to change the position and parent of an MTO category. Other categories will automatically
+   * have their positions changed to adjust to the new position of the new category.
+   * If only the parent is changed, the category will be placed as the last category in order for the group of subcategories
+   * Note, a subcategory can't become a subcategory and vice versa
+   */
   reorderMTOCategory: MtoCategory;
   reportAProblem: Scalars['Boolean']['output'];
   /** This mutation sends feedback about the MINT product to the MINT team */
@@ -1329,7 +1335,8 @@ export type MutationRenameMtoCategoryArgs = {
 /** Mutations definition for the schema */
 export type MutationReorderMtoCategoryArgs = {
   id: Scalars['UUID']['input'];
-  newOrder: Scalars['Int']['input'];
+  newOrder?: InputMaybe<Scalars['Int']['input']>;
+  parentID?: InputMaybe<Scalars['UUID']['input']>;
 };
 
 


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [MINT-1234] [MINT-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# MINT-3212

## Description
<!--
REQUIRED
    Provide details as to what the PR aims to accomplish
    Be as descriptive as you can, and include any relevant information that will help the reviewer understand the scope of the changes
    Include screenshots or screen recordings to assist in reviewing if possible.
-->
This is a follow up to https://github.com/CMS-Enterprise/mint-app/pull/1511 after discovering a new requirement to be able to change a parent id of a child category.
A parent can't become a child.

This was accomplished by modifying the trigger to handle when a parent was changed to update the children of the old parent like a delete, and the parent of the new children like an insert. If an order is not specified for a new parent, the app code will provide the max of the current positions, effectively putting it at the end of the categories.


## How to test this change
<!--
REQUIRED
    Add instructions on how to test the changes in this PR
    This can be a list of steps to reproduce a bug, or a list of steps to verify a feature in the application
    Include any example shell commands, SQL queries/commands, or Postman requests that reviewers can run to test the changes
-->
NOTE!!! If you haven't reviewed and approved https://github.com/CMS-Enterprise/mint-app/pull/1511, please review that PR first. This builds on top of that PR, and will be simpler to review in that context.
1.  Run all unit tests
2.  Use Postment
3. Make categories
4. Change the parent and order
5. Validate the old parent children positions update as expected
6. Validate the new parent children positions update as expected
7. Validate that you can't make a parent category a child
8. Validate that you have to provide either an order or a parent, or you will get an error.

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
