### PR TITLE
[MINT-3238] Standard Categories

### DIFF
--- a/MINT.postman_collection.json
+++ b/MINT.postman_collection.json
@@ -2818,6 +2818,39 @@
 					"name": "Categories",
 					"item": [
 						{
+							"name": "Create Standard Categories",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "mutation CreateStandardCategories {\n    createStandardCategories(modelPlanID: \"{{modelPlanID}}\")\n}",
+										"variables": ""
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "GetMTOCategories",
 							"request": {
 								"method": "POST",

--- a/pkg/graph/resolvers/mto_category.resolvers.go
+++ b/pkg/graph/resolvers/mto_category.resolvers.go
@@ -58,6 +58,13 @@ func (r *mutationResolver) ReorderMTOCategory(ctx context.Context, id uuid.UUID,
 	return MTOCategoryReorder(ctx, logger, principal, r.store, id, newOrder, parentID)
 }
 
+// CreateStandardCategories is the resolver for the createStandardCategories field.
+func (r *mutationResolver) CreateStandardCategories(ctx context.Context, modelPlanID uuid.UUID) (bool, error) {
+	principal := appcontext.Principal(ctx)
+	logger := appcontext.ZLogger(ctx)
+	return MTOCreateStandardCategories(ctx, logger, principal, r.store, modelPlanID)
+}
+
 // MTOCategory returns generated.MTOCategoryResolver implementation.
 func (r *Resolver) MTOCategory() generated.MTOCategoryResolver { return &mTOCategoryResolver{r} }
 

--- a/pkg/graph/resolvers/mto_category_test.go
+++ b/pkg/graph/resolvers/mto_category_test.go
@@ -668,7 +668,7 @@ func (suite *ResolverSuite) TestMTOCreateStandardCategories() {
 		return c.ParentID != nil
 	})
 
-	suite.Len(categoriesAfterRename, 21) // total
+	suite.Len(categoriesAfterRename, 21) // total (three more than before)
 	suite.Equal(9, numCategories)        // just top-level categories (one more than before)
 	suite.Equal(12, numSubcategories)    // just subcategories (two more than before)
 }

--- a/pkg/graph/schema/types/mto_category.graphql
+++ b/pkg/graph/schema/types/mto_category.graphql
@@ -53,4 +53,11 @@ extend type Mutation {
   """
   reorderMTOCategory(id: UUID!, newOrder: Int, parentID: UUID): MTOCategory!
   @hasRole(role: MINT_USER)
+
+  """
+  Automatically attempts to create a series of categories and subcategories by name. If any specific category/subcategory already exists, it will
+  still create the others
+  """
+  createStandardCategories(modelPlanID: UUID!): Boolean!
+  @hasRole(role: MINT_USER)
 }

--- a/pkg/sqlutils/transactions.go
+++ b/pkg/sqlutils/transactions.go
@@ -36,3 +36,12 @@ func WithTransaction[T any](txPrep TransactionPreparer, txFunc TransactionFunc[T
 
 	return result, nil
 }
+
+// WithTransactionNoReturn is used for transactions that are execution only (i.e., no return value) and only returns an error
+func WithTransactionNoReturn(txPrep TransactionPreparer, txFunc func(*sqlx.Tx) error) error {
+	_, err := WithTransaction[any](txPrep, func(tx *sqlx.Tx) (*any, error) {
+		return nil, txFunc(tx)
+	})
+
+	return err
+}

--- a/src/gql/generated/graphql.ts
+++ b/src/gql/generated/graphql.ts
@@ -1255,6 +1255,11 @@ export type Mutation = {
   createPlanDiscussion: PlanDiscussion;
   createPlanDocumentSolutionLinks?: Maybe<Array<PlanDocumentSolutionLink>>;
   createPlanTDL: PlanTdl;
+  /**
+   * Automatically attempts to create a series of categories and subcategories by name. If any specific category/subcategory already exists, it will
+   * still create the others
+   */
+  createStandardCategories: Scalars['Boolean']['output'];
   deleteOperationalSolutionSubtask: Scalars['Int']['output'];
   deletePlanCR: PlanCr;
   deletePlanCollaborator: PlanCollaborator;
@@ -1431,6 +1436,12 @@ export type MutationCreatePlanDocumentSolutionLinksArgs = {
 /** Mutations definition for the schema */
 export type MutationCreatePlanTdlArgs = {
   input: PlanTdlCreateInput;
+};
+
+
+/** Mutations definition for the schema */
+export type MutationCreateStandardCategoriesArgs = {
+  modelPlanID: Scalars['UUID']['input'];
 };
 
 


### PR DESCRIPTION
<!--
REQUIRED
    Ensure that your PR title has the relevant Jira ticket number(s) in the title.
    Follow this pattern: [MINT-1234] [MINT-4567] Title of the PR.
    Use [NOREF] in place of a ticket number when there's no associated Jira ticket.
    The heading below should just have the ticket numbers (for easy linking in Jira)
-->
# MINT-3238

## Description
<!--
REQUIRED
    Provide details as to what the PR aims to accomplish
    Be as descriptive as you can, and include any relevant information that will help the reviewer understand the scope of the changes
    Include screenshots or screen recordings to assist in reviewing if possible.
-->
- Adds a new mutation that creates a standard set of categories and subcategories when called.
- Adds `Resolver` suite tests to cover new behavior
- Adds new Postman query

> [!NOTE]
> This PR adds a `sqlutils.WithTransactionNoReturn` method, which is equivalent to `sqlutils.WithTransaction`, except that it doesn't return any values -- useful for if you need to call a bunch of storage methods as part of a transaction but don't care about a specific return value (just if an error occurred)

> [!CAUTION]
> I took the approach of sequentially calling a storage method as part of a transaction rather than trying to create a complex SQL/Storage method that would bulk insert these (since allowing conflicts and ordering seemed like a difficult solve)
> There's currently a `TODO` in the codebase here to consider refactoring this, but it seems to work well enough as-is

## How to test this change
<!--
REQUIRED
    Add instructions on how to test the changes in this PR
    This can be a list of steps to reproduce a bug, or a list of steps to verify a feature in the application
    Include any example shell commands, SQL queries/commands, or Postman requests that reviewers can run to test the changes
-->
1.  Create a new model plan (or use an existing one from `scripts/dev db:seed`)
2. In postman, call the new `createStandardCategories` mutation that was added with the appropriate model plan ID
3. In postman, call `GetMTOCategories` to fetch the list of categories and subcategories to make sure everything works as expected!

> [!TIP]
> You can also try renaming categories and ensuring the `createStandardCategories` mutation re-creates them! (They will appear at the end of the categories list when re-created)

> [!NOTE]
> At time of writing, the UI won't properly handle rendering empty categories in the MTO Matrix page, so please test this feature using Postman!
> This is addressed in https://github.com/CMS-Enterprise/mint-app/pull/1556

## PR Author Checklist
<!--
REQUIRED
    Ensure that each of the following is true before you submit this PR (or before it leaves "draft" status), and check each box to confirm
-->

- [x] I have provided a detailed description of the changes in this PR.
- [x] I have provided clear instructions on how to test the changes in this PR.
- [x] I have updated tests or written new tests as appropriate in this PR.
- [x] Updated the [Postman Collection](../MINT.postman_collection.json) if necessary.


## PR Reviewer Guidelines
<!--
This is just some static content to ensure we're following best practices when reviewing.
There is no need to edit this section.
-->
- It's best to pull the branch locally and test it, rather than just looking at the code online!
- When approving a PR, provide a reason _why_ you're approving it
  - e.g. "Approving because I tested it locally and all functionality works as expected"
  - e.g. "Approving because the change is simple and matches the Figma design"
- Don't be afraid to leave comments or ask questions, especially if you don't understand why something was done! (This is often a great time to suggest code comments or documentation updates)
- Check that all code is adequately covered by tests - if it isn't feel free to suggest the addition of tests.
